### PR TITLE
Add fallback when SDS indicators aren't present

### DIFF
--- a/app/assets/scripts/views/project.js
+++ b/app/assets/scripts/views/project.js
@@ -86,7 +86,7 @@ var Project = React.createClass({
 
     const allProjects = get(this.props.api, 'projects', []);
 
-    const sdsGoals = get(data, 'sds_indicator').join(',');
+    const sdsGoals = get(data, 'sds_indicator', []).join(',');
     const relatedProjects = allProjects.filter(function (project) {
       if (meta.id === project.id) { return false; } // don't include itself
       if (!Array.isArray(project.sds_indicators)) { return false; }


### PR DESCRIPTION
The bug that caused some project pages not to show is due to some projects not having any SDS Indicator properties.

I'm raising this as it seems pertinent to this particular issue: I've noticed that most or all the data in this site is test data, and much of it is incomplete. When building this site, we made some necessary assumptions about the data we would visualize. If that data structure doesn't hold true, those assumptions will fall over and the site will malfunction.

@hagareldidi I'm happy to fix bugs and oversights, but I'm not able to develop an application that can account for the wide gamut of development data scenarios. I believe for this app to progress into usefulness, it will need fuller and richer data that is closer to production data, along the lines of what's in Map Egypt currently. 